### PR TITLE
Fix for "MAX_BLOCK_SIZE" bug in main.h

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -57,9 +57,9 @@ static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 0;
 /** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 27000;
 /** The maximum size for mined blocks */
-static const unsigned int MAX_BLOCK_SIZE_GEN = MAX_BLOCK_SIZE/2;         // 250KB  block soft limit
+static const unsigned int MAX_BLOCK_SIZE_GEN = MAX_BLOCK_SIZE/32;         // 250KB  block soft limit
 /** The maximum size for transactions we're willing to relay/mine */
-static const unsigned int MAX_STANDARD_TX_SIZE = MAX_BLOCK_SIZE_GEN/4; //DEFAULT_BLOCK_MAX_SIZE/2.5;
+static const unsigned int MAX_STANDARD_TX_SIZE = MAX_BLOCK_SIZE_GEN/5; //DEFAULT_BLOCK_MAX_SIZE/2.5;
 /** The maximum allowed number of signature check operations in a block (network rule) */
 static const unsigned int MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE/100; //MAX_BLOCK_SIZE/50; //MAX_BLOCK_SIZE/100;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */


### PR DESCRIPTION
Representing "/2;" whereas should be "/32'" and "DEFAULT_BLOCK_MAX_SIZE" modified to 5 which correctly calculates fee structure and reduce orphan transactions.